### PR TITLE
Sustituir harina blanca por harina de fuerza en masa madre espelta

### DIFF
--- a/recetas/masa-madre-espelta.md
+++ b/recetas/masa-madre-espelta.md
@@ -1,7 +1,7 @@
 # Masa madre para pan de espelta
 
 **Ingredientes** para añadir la masa madre a un pan de un 1 kg. de harina:
-* 125 gr. de harina blanca.
+* 125 gr. de harina de fuerza.
 * 125 gr. de harina de espelta.
 * 25 gr. de levadura.
 * Agua.


### PR DESCRIPTION
Sustituir harina blanca por harina de fuerza en la receta de masa madre de espelta.