### PR TITLE
Especificar que la masa madre necesita levadura de panadería.

### DIFF
--- a/recetas/masa-madre-espelta.md
+++ b/recetas/masa-madre-espelta.md
@@ -3,7 +3,7 @@
 **Ingredientes** para añadir la masa madre a un pan de un 1 kg. de harina:
 * 85 gr. de harina de fuerza.
 * 85 gr. de harina de espelta.
-* 25 gr. de levadura.
+* 25 gr. de levadura de panadería.
 * Agua.
 * Sal.
 


### PR DESCRIPTION
Especificar que la masa madre necesita levadura de panadería. Hay diferentes tipos de levadura. En el supermercado hay que comprar la específica para pan, pues es diferente que la que se usa para repostería o para hacer cerveza artesanal, por ejemplo.