### PR TITLE
Corregido error gramatical: harina debe ir en minúscula.

### DIFF
--- a/recetas/pan-espelta.md
+++ b/recetas/pan-espelta.md
@@ -1,8 +1,8 @@
 # Pan de espelta
 
 **Ingredientes**:
-* 1/2 kg. de Harina de fuerza.
-* 1/2 kg. de Harina de espelta.
+* 1/2 kg. de harina de fuerza.
+* 1/2 kg. de harina de espelta.
 * 165 gr. de masa madre.
 * Agua.
 * Sal.


### PR DESCRIPTION
He corregido en el pan de espelta la palabra *Harina* para que estuviese en minúscula, pues forma parte de la frase.